### PR TITLE
feat(adapters): configurable default adapter via MOONBRIDGE_ADAPTER env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ All tools return JSON with these fields:
 
 | Variable | Description |
 |----------|-------------|
+| `MOONBRIDGE_ADAPTER` | Default adapter (default: `kimi`) |
 | `MOONBRIDGE_TIMEOUT` | Default timeout in seconds (30-3600) |
 | `MOONBRIDGE_MAX_AGENTS` | Maximum parallel agents |
 | `MOONBRIDGE_ALLOWED_DIRS` | Colon-separated allowlist of working directories |

--- a/src/moonbridge/adapters/__init__.py
+++ b/src/moonbridge/adapters/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from .base import AdapterConfig, CLIAdapter
 from .kimi import KimiAdapter
 
@@ -6,8 +8,15 @@ _ADAPTERS: dict[str, CLIAdapter] = {
 }
 
 
-def get_adapter(name: str = "kimi") -> CLIAdapter:
-    """Get adapter by name. Defaults to kimi."""
+def get_adapter(name: str | None = None) -> CLIAdapter:
+    """Get adapter by name.
+
+    Args:
+        name: Adapter name. If None, uses MOONBRIDGE_ADAPTER env var,
+            falling back to "kimi" if unset or empty.
+    """
+    if name is None:
+        name = (os.environ.get("MOONBRIDGE_ADAPTER") or "").strip() or "kimi"
     if name not in _ADAPTERS:
         available = ", ".join(sorted(_ADAPTERS))
         raise ValueError(f"Unknown adapter: {name}. Available: {available}")

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -32,8 +32,35 @@ def test_kimi_adapter_check_not_installed(mocker):
     assert path is None
 
 
-def test_get_adapter_default():
+def test_get_adapter_default(monkeypatch):
+    monkeypatch.delenv("MOONBRIDGE_ADAPTER", raising=False)
     adapter: CLIAdapter = get_adapter()
+    assert adapter.config.name == "kimi"
+
+
+def test_get_adapter_env_override(monkeypatch):
+    monkeypatch.setenv("MOONBRIDGE_ADAPTER", "kimi")
+    adapter = get_adapter()
+    assert isinstance(adapter, KimiAdapter)
+
+
+def test_get_adapter_env_invalid_raises(monkeypatch):
+    monkeypatch.setenv("MOONBRIDGE_ADAPTER", "nonexistent")
+    with pytest.raises(ValueError, match="Unknown adapter: nonexistent. Available: kimi"):
+        get_adapter()
+
+
+def test_get_adapter_explicit_name_overrides_env(monkeypatch):
+    """Explicit name parameter takes precedence over env var."""
+    monkeypatch.setenv("MOONBRIDGE_ADAPTER", "nonexistent")
+    adapter = get_adapter("kimi")
+    assert adapter.config.name == "kimi"
+
+
+def test_get_adapter_env_whitespace_falls_back_to_default(monkeypatch):
+    """Whitespace-only env var falls back to default."""
+    monkeypatch.setenv("MOONBRIDGE_ADAPTER", "  ")
+    adapter = get_adapter()
     assert adapter.config.name == "kimi"
 
 


### PR DESCRIPTION
## Summary

- Add `MOONBRIDGE_ADAPTER` env var to select default adapter at runtime
- Falls back to `kimi` when not set  
- Invalid adapter names produce helpful error message listing available options
- Document new env var in README.md

## Test plan

- [x] Test default behavior (no env var = kimi)
- [x] Test env var override works
- [x] Test invalid adapter name error message
- [x] Full test suite passes (21 tests)
- [x] Type checking passes (mypy)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default adapter can now be configured via the MOONBRIDGE_ADAPTER environment variable.
  * Added a public way to list available adapters.

* **Documentation**
  * README updated to document the MOONBRIDGE_ADAPTER environment variable.

* **Tests**
  * New tests cover environment-variable handling, explicit-name overrides, whitespace fallback, invalid-value errors, and default behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->