### PR TITLE
fix(ci): trigger publish.yml instead of duplicating PyPI publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
@@ -27,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger publish workflow
-        run: gh workflow run publish.yml --ref "${{ needs.release-please.outputs.tag_name }}"
+        run: gh workflow run publish.yml --ref "${{ needs.release-please.outputs.tag_name }}" -f ref="${{ needs.release-please.outputs.tag_name }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Removes duplicate PyPI publish logic from release-please.yml
- Instead triggers the existing publish.yml workflow (which already has trusted publisher configured)
- Eliminates need for a second PyPI trusted publisher

## Test plan
- [ ] Merge this PR
- [ ] Next release-please PR merge will trigger publish.yml automatically

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured the release workflow into a two-stage process that triggers an external publish workflow instead of doing in-line publishing.
  * Renamed the publish job and updated workflow permissions.
  * Removed direct build/publish steps and added a single trigger step that supplies repository and token environments for the external workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->