### PR TITLE
feat: add copy-on-run sandbox mode for agent execution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ uv build                     # Build package
 ```
 src/moonbridge/
 ├── server.py          # MCP server implementation, tool handlers, process management
+├── sandbox.py         # Copy-on-run sandbox + diff utilities
 ├── version_check.py   # Update notification (24h cache)
 └── adapters/
     ├── base.py        # CLIAdapter protocol and AdapterConfig dataclass

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ All tools return JSON with these fields:
 | `MOONBRIDGE_SANDBOX` | Set to `1` to run agents in a temp copy of cwd |
 | `MOONBRIDGE_SANDBOX_KEEP` | Set to `1` to keep sandbox dir for inspection |
 | `MOONBRIDGE_SANDBOX_MAX_DIFF` | Max diff size in bytes (default 500000) |
+| `MOONBRIDGE_SANDBOX_MAX_COPY` | Max sandbox copy size in bytes (default 500MB) |
 | `MOONBRIDGE_LOG_LEVEL` | Set to `DEBUG` for verbose logging |
 
 ## Troubleshooting
@@ -222,6 +223,7 @@ Optional:
 ```bash
 export MOONBRIDGE_SANDBOX_KEEP=1       # keep temp dir
 export MOONBRIDGE_SANDBOX_MAX_DIFF=200000
+export MOONBRIDGE_SANDBOX_MAX_COPY=300000000
 ```
 
 Limitations: this is not OS-level isolation. Agents can still read/write arbitrary host paths if they choose to. Use containers/VMs for strong isolation.

--- a/src/moonbridge/sandbox.py
+++ b/src/moonbridge/sandbox.py
@@ -1,0 +1,252 @@
+"""Copy-on-run sandbox for agent execution."""
+
+from __future__ import annotations
+
+import difflib
+import os
+import shutil
+import tempfile
+import time
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from moonbridge.adapters.base import AgentResult
+
+SANDBOX_IGNORE_DIRS = {
+    ".git",
+    ".venv",
+    ".tox",
+    "__pycache__",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    "node_modules",
+    "dist",
+    "build",
+}
+SANDBOX_IGNORE_FILES = {".DS_Store"}
+MAX_COPY_BYTES = 500 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class SandboxResult:
+    diff: str
+    summary: dict[str, int]
+    truncated: bool
+    sandbox_path: str | None
+
+
+def _should_ignore(name: str) -> bool:
+    if name in SANDBOX_IGNORE_DIRS:
+        return True
+    if name in SANDBOX_IGNORE_FILES:
+        return True
+    return name.endswith((".pyc", ".pyo"))
+
+
+def _ignore_names(_dirpath: str, names: list[str]) -> set[str]:
+    return {name for name in names if _should_ignore(name)}
+
+
+def _filtered_walk(root: str) -> Iterator[tuple[str, list[str], list[str]]]:
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if not _should_ignore(d)]
+        filenames = [f for f in filenames if not _should_ignore(f)]
+        yield dirpath, dirnames, filenames
+
+
+def _collect_files(root: str) -> set[str]:
+    files: set[str] = set()
+    for dirpath, _dirnames, filenames in _filtered_walk(root):
+        rel_dir = os.path.relpath(dirpath, root)
+        for filename in filenames:
+            rel_path = filename if rel_dir == "." else os.path.join(rel_dir, filename)
+            files.add(rel_path)
+    return files
+
+
+def _read_text(path: str) -> str | None:
+    data = Path(path).read_bytes()
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
+def _diff_trees(
+    original: str,
+    sandbox: str,
+    max_bytes: int,
+) -> tuple[str, dict[str, int], bool]:
+    original_files = _collect_files(original)
+    sandbox_files = _collect_files(sandbox)
+    all_files = sorted(original_files | sandbox_files)
+    diff_chunks: list[str] = []
+    size = 0
+    truncated = False
+    summary = {"added": 0, "modified": 0, "deleted": 0, "binary": 0}
+
+    def append_chunk(chunk: str) -> None:
+        nonlocal size, truncated
+        if truncated or not chunk:
+            return
+        remaining = max_bytes - size
+        if remaining <= 0:
+            truncated = True
+            return
+        if len(chunk) > remaining:
+            diff_chunks.append(chunk[:remaining])
+            truncated = True
+            size = max_bytes
+            return
+        diff_chunks.append(chunk)
+        size += len(chunk)
+
+    for rel_path in all_files:
+        original_path = os.path.join(original, rel_path)
+        sandbox_path = os.path.join(sandbox, rel_path)
+        original_exists = os.path.exists(original_path)
+        sandbox_exists = os.path.exists(sandbox_path)
+
+        if not original_exists and sandbox_exists:
+            summary["added"] += 1
+            sandbox_text = _read_text(sandbox_path)
+            if sandbox_text is None:
+                summary["binary"] += 1
+                append_chunk(f"Binary files /dev/null and b/{rel_path} differ\n")
+                continue
+            diff = difflib.unified_diff(
+                [],
+                sandbox_text.splitlines(keepends=True),
+                fromfile="/dev/null",
+                tofile=f"b/{rel_path}",
+            )
+            append_chunk("".join(diff))
+            continue
+
+        if original_exists and not sandbox_exists:
+            summary["deleted"] += 1
+            original_text = _read_text(original_path)
+            if original_text is None:
+                summary["binary"] += 1
+                append_chunk(f"Binary files a/{rel_path} and /dev/null differ\n")
+                continue
+            diff = difflib.unified_diff(
+                original_text.splitlines(keepends=True),
+                [],
+                fromfile=f"a/{rel_path}",
+                tofile="/dev/null",
+            )
+            append_chunk("".join(diff))
+            continue
+
+        if not original_exists or not sandbox_exists:
+            continue
+
+        original_bytes = Path(original_path).read_bytes()
+        sandbox_bytes = Path(sandbox_path).read_bytes()
+        if original_bytes == sandbox_bytes:
+            continue
+
+        original_text = None
+        sandbox_text = None
+        try:
+            original_text = original_bytes.decode("utf-8")
+            sandbox_text = sandbox_bytes.decode("utf-8")
+        except UnicodeDecodeError:
+            summary["binary"] += 1
+            append_chunk(f"Binary files a/{rel_path} and b/{rel_path} differ\n")
+            continue
+
+        summary["modified"] += 1
+        diff = difflib.unified_diff(
+            original_text.splitlines(keepends=True),
+            sandbox_text.splitlines(keepends=True),
+            fromfile=f"a/{rel_path}",
+            tofile=f"b/{rel_path}",
+        )
+        append_chunk("".join(diff))
+
+    if truncated:
+        diff_chunks.append("\n... diff truncated ...\n")
+    return ("".join(diff_chunks), summary, truncated)
+
+
+def _estimate_copy_size(root: str, max_bytes: int) -> int:
+    total = 0
+    for dirpath, _dirnames, filenames in _filtered_walk(root):
+        for filename in filenames:
+            path = os.path.join(dirpath, filename)
+            total += os.path.getsize(path)
+            if total > max_bytes:
+                return total
+    return total
+
+
+def _agent_index(fn: Callable[[str], AgentResult]) -> int:
+    value = getattr(fn, "agent_index", 0)
+    return value if isinstance(value, int) else 0
+
+
+def run_sandboxed(
+    fn: Callable[[str], AgentResult],
+    cwd: str,
+    *,
+    max_diff_bytes: int = 500_000,
+    max_copy_bytes: int = MAX_COPY_BYTES,
+    keep: bool = False,
+) -> tuple[AgentResult, SandboxResult | None]:
+    """Run fn in a copy of cwd. Returns (agent_result, sandbox_result).
+
+    On sandbox infrastructure error, returns (error_result, None).
+    """
+    start = time.monotonic()
+    sandbox_root: str | None = None
+    agent_index = _agent_index(fn)
+
+    def error_result(reason: str) -> AgentResult:
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return AgentResult(
+            status="error",
+            output="",
+            stderr=f"sandbox error: {reason}",
+            returncode=-1,
+            duration_ms=duration_ms,
+            agent_index=agent_index,
+        )
+
+    try:
+        total_bytes = _estimate_copy_size(cwd, max_copy_bytes)
+        if total_bytes > max_copy_bytes:
+            return error_result(
+                f"copy size {total_bytes} exceeds max {max_copy_bytes}"
+            ), None
+
+        sandbox_root = tempfile.mkdtemp(prefix="moonbridge-sandbox-")
+        sandbox_cwd = os.path.join(sandbox_root, "workspace")
+        shutil.copytree(cwd, sandbox_cwd, symlinks=False, ignore=_ignore_names)
+
+        result = fn(sandbox_cwd)
+
+        try:
+            diff, summary, truncated = _diff_trees(cwd, sandbox_cwd, max_diff_bytes)
+            sandbox_result = SandboxResult(
+                diff=diff,
+                summary=summary,
+                truncated=truncated,
+                sandbox_path=sandbox_root if keep else None,
+            )
+            return result, sandbox_result
+        except Exception as exc:
+            raw = dict(result.raw or {})
+            sandbox_payload: dict[str, object] = {"enabled": True, "error": str(exc)}
+            if keep:
+                sandbox_payload["path"] = sandbox_root
+            raw["sandbox"] = sandbox_payload
+            return replace(result, raw=raw), None
+    except Exception as exc:
+        return error_result(str(exc)), None
+    finally:
+        if not keep and sandbox_root:
+            shutil.rmtree(sandbox_root, ignore_errors=True)

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,221 @@
+import importlib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from moonbridge.adapters.base import AgentResult
+
+sandbox_module = importlib.import_module("moonbridge.sandbox")
+
+
+def _success_result(agent_index: int = 0) -> AgentResult:
+    return AgentResult(
+        status="success",
+        output="ok",
+        stderr=None,
+        returncode=0,
+        duration_ms=1,
+        agent_index=agent_index,
+    )
+
+
+def test_diff_trees_no_changes(tmp_path: Path) -> None:
+    original = tmp_path / "original"
+    sandbox = tmp_path / "sandbox"
+    original.mkdir()
+    sandbox.mkdir()
+    (original / "a.txt").write_text("same", encoding="utf-8")
+    (sandbox / "a.txt").write_text("same", encoding="utf-8")
+
+    diff, summary, truncated = sandbox_module._diff_trees(
+        str(original), str(sandbox), 500_000
+    )
+
+    assert diff == ""
+    assert summary == {"added": 0, "modified": 0, "deleted": 0, "binary": 0}
+    assert truncated is False
+
+
+def test_diff_trees_truncation(tmp_path: Path) -> None:
+    original = tmp_path / "original"
+    sandbox = tmp_path / "sandbox"
+    original.mkdir()
+    sandbox.mkdir()
+    (sandbox / "big.txt").write_text("x" * 1000, encoding="utf-8")
+
+    diff, summary, truncated = sandbox_module._diff_trees(str(original), str(sandbox), 50)
+
+    assert truncated is True
+    assert "... diff truncated ..." in diff
+    assert summary["added"] == 1
+
+
+def test_diff_trees_binary_file(tmp_path: Path) -> None:
+    original = tmp_path / "original"
+    sandbox = tmp_path / "sandbox"
+    original.mkdir()
+    sandbox.mkdir()
+    (sandbox / "img.bin").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x80\xff")
+
+    diff, summary, truncated = sandbox_module._diff_trees(
+        str(original), str(sandbox), 500_000
+    )
+
+    assert summary["added"] == 1
+    assert summary["binary"] == 1
+    assert "Binary files" in diff
+    assert truncated is False
+
+
+def test_run_sandboxed_keep_preserves_dir(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "keep.txt").write_text("keep", encoding="utf-8")
+
+    sandbox_root = tmp_path / "sandbox"
+
+    def fake_mkdtemp(*_args: Any, **_kwargs: Any) -> str:
+        sandbox_root.mkdir()
+        return str(sandbox_root)
+
+    monkeypatch.setattr(sandbox_module.tempfile, "mkdtemp", fake_mkdtemp)
+
+    result, sandbox_result = sandbox_module.run_sandboxed(
+        lambda _cwd: _success_result(),
+        str(workspace),
+        keep=True,
+    )
+
+    assert result.status == "success"
+    assert sandbox_result is not None
+    assert sandbox_result.sandbox_path == str(sandbox_root)
+    assert sandbox_root.exists()
+
+
+def test_run_sandboxed_cleanup_on_success(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "keep.txt").write_text("keep", encoding="utf-8")
+
+    sandbox_root = tmp_path / "sandbox"
+
+    def fake_mkdtemp(*_args: Any, **_kwargs: Any) -> str:
+        sandbox_root.mkdir()
+        return str(sandbox_root)
+
+    monkeypatch.setattr(sandbox_module.tempfile, "mkdtemp", fake_mkdtemp)
+
+    result, sandbox_result = sandbox_module.run_sandboxed(
+        lambda _cwd: _success_result(),
+        str(workspace),
+        keep=False,
+    )
+
+    assert result.status == "success"
+    assert sandbox_result is not None
+    assert not sandbox_root.exists()
+
+
+def test_run_sandboxed_cleanup_on_error(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "keep.txt").write_text("keep", encoding="utf-8")
+
+    sandbox_root = tmp_path / "sandbox"
+
+    def fake_mkdtemp(*_args: Any, **_kwargs: Any) -> str:
+        sandbox_root.mkdir()
+        return str(sandbox_root)
+
+    monkeypatch.setattr(sandbox_module.tempfile, "mkdtemp", fake_mkdtemp)
+
+    def boom(_cwd: str) -> AgentResult:
+        raise RuntimeError("boom")
+
+    result, sandbox_result = sandbox_module.run_sandboxed(boom, str(workspace))
+
+    assert result.status == "error"
+    assert sandbox_result is None
+    assert not sandbox_root.exists()
+
+
+def test_diff_failure_returns_error_in_sandbox(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "keep.txt").write_text("keep", encoding="utf-8")
+
+    def raise_diff(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(sandbox_module, "_diff_trees", raise_diff)
+
+    result, sandbox_result = sandbox_module.run_sandboxed(
+        lambda _cwd: _success_result(),
+        str(workspace),
+    )
+
+    assert result.status == "success"
+    assert sandbox_result is None
+    assert result.raw is not None
+    assert "sandbox" in result.raw
+    assert "error" in result.raw["sandbox"]
+
+
+def test_max_copy_size_exceeded(
+    monkeypatch: Any,
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "big.txt").write_bytes(b"x" * 20)
+
+    def no_copy(*_args: Any, **_kwargs: Any) -> Any:
+        raise AssertionError("copy should not start")
+
+    monkeypatch.setattr(sandbox_module.tempfile, "mkdtemp", no_copy)
+
+    def should_not_run(_cwd: str) -> AgentResult:
+        raise AssertionError("agent should not run")
+
+    result, sandbox_result = sandbox_module.run_sandboxed(
+        should_not_run,
+        str(workspace),
+        max_copy_bytes=10,
+    )
+
+    assert result.status == "error"
+    assert result.stderr
+    assert "exceeds max" in result.stderr
+    assert sandbox_result is None
+
+
+def test_ignore_patterns_unified(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".DS_Store").write_text("ignored", encoding="utf-8")
+
+    def run_agent(sandbox_cwd: str) -> AgentResult:
+        sandbox_path = Path(sandbox_cwd)
+        assert not sandbox_path.joinpath(".DS_Store").exists()
+        sandbox_path.joinpath(".DS_Store").write_text("new", encoding="utf-8")
+        return _success_result()
+
+    result, sandbox_result = sandbox_module.run_sandboxed(run_agent, str(workspace))
+
+    assert result.status == "success"
+    assert sandbox_result is not None
+    assert sandbox_result.diff == ""
+    assert sandbox_result.summary == {"added": 0, "modified": 0, "deleted": 0, "binary": 0}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -660,49 +660,6 @@ def test_run_cli_sandboxed_diff_and_preserves_host(
     assert (workspace / "remove.txt").exists()
 
 
-def test_diff_trees_no_changes(tmp_path: Any) -> None:
-    original = tmp_path / "original"
-    sandbox = tmp_path / "sandbox"
-    original.mkdir()
-    sandbox.mkdir()
-    (original / "a.txt").write_text("same", encoding="utf-8")
-    (sandbox / "a.txt").write_text("same", encoding="utf-8")
-
-    diff, summary, truncated = server_module._diff_trees(str(original), str(sandbox), 500_000)
-
-    assert diff == ""
-    assert summary == {"added": 0, "modified": 0, "deleted": 0, "binary": 0}
-    assert truncated is False
-
-
-def test_diff_trees_truncation(tmp_path: Any) -> None:
-    original = tmp_path / "original"
-    sandbox = tmp_path / "sandbox"
-    original.mkdir()
-    sandbox.mkdir()
-    (sandbox / "big.txt").write_text("x" * 1000, encoding="utf-8")
-
-    diff, summary, truncated = server_module._diff_trees(str(original), str(sandbox), 50)
-
-    assert truncated is True
-    assert "... diff truncated ..." in diff
-    assert summary["added"] == 1
-
-
-def test_diff_trees_binary_file(tmp_path: Any) -> None:
-    original = tmp_path / "original"
-    sandbox = tmp_path / "sandbox"
-    original.mkdir()
-    sandbox.mkdir()
-    (sandbox / "img.bin").write_bytes(b"\x89PNG\r\n\x1a\n\x00\x80\xff")
-
-    diff, summary, truncated = server_module._diff_trees(str(original), str(sandbox), 500_000)
-
-    assert summary["added"] == 1
-    assert summary["binary"] == 1
-    assert "Binary files" in diff
-
-
 def test_run_cli_sandboxed_copytree_error(
     monkeypatch: Any,
     tmp_path: Any,


### PR DESCRIPTION
## Summary

Closes #68. Adds optional sandbox mode that runs agents in a temporary copy of the working directory.

- Copy-on-run isolation: MOONBRIDGE_SANDBOX=1 runs agents in temp copies of cwd, keeping host files unchanged
- Unified diff output: Returns unified diff + summary (added/modified/deleted/binary counts) in raw.sandbox
- Extracted sandbox.py module: Deep module with unified ignore logic, copy-size guard (500MB), and clean run_sandboxed() interface
- Defense-in-depth: Symlinks not followed during copy, copy-size limit prevents disk exhaustion, diff truncation at configurable limit

### Environment Variables

| Variable | Default | Purpose |
|----------|---------|---------|
| MOONBRIDGE_SANDBOX | 0 | Enable sandbox mode |
| MOONBRIDGE_SANDBOX_KEEP | 0 | Keep sandbox dir for inspection |
| MOONBRIDGE_SANDBOX_MAX_DIFF | 500000 | Max diff output bytes |
| MOONBRIDGE_SANDBOX_MAX_COPY | 500MB | Max workspace copy size |

## Test plan

- [x] 169 tests pass (9 new sandbox-specific tests)
- [x] ruff check clean
- [x] mypy clean
- [x] Tested: no changes produces empty diff
- [x] Tested: diff truncation at byte limit
- [x] Tested: binary file detection
- [x] Tested: copy-size guard rejects oversized workspaces
- [x] Tested: SANDBOX_KEEP preserves temp dir
- [x] Tested: cleanup on success and error paths
- [x] Tested: unified ignore patterns match between copy and diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox Mode (copy-on-run) for CLI agent runs with configurable options (enable, keep sandbox, max diff size, max copy size)
  * JSON responses include an optional "raw" field carrying sandbox metadata and unified diffs of changes

* **Documentation**
  * Added usage docs and examples for Sandbox Mode, caveats about isolation, and recommended stronger isolation approaches

* **Tests**
  * Comprehensive sandbox tests covering diffs, lifecycle, size limits, ignores, and error paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->