### PR TITLE
docs: add Security section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ All tools return JSON with these fields:
 
 ### 1. Directory Restrictions (`MOONBRIDGE_ALLOWED_DIRS`)
 
-Default: agents can operate in any directory. Set `MOONBRIDGE_ALLOWED_DIRS` to restrict: colon-separated allowed paths. Symlinks resolved via `os.path.realpath` before checking. Strict mode (`MOONBRIDGE_STRICT=1`) exits on startup if `ALLOWED_DIRS` is unset.
+Default: agents can operate in any directory. Set `MOONBRIDGE_ALLOWED_DIRS` to restrict: colon-separated allowed paths. Symlinks resolved via `os.path.realpath` before checking. Strict mode (`MOONBRIDGE_STRICT=1`) exits on startup if no valid allowed directories are configured.
 
 ```bash
 export MOONBRIDGE_ALLOWED_DIRS="/home/user/projects:/home/user/work"
@@ -156,13 +156,15 @@ export MOONBRIDGE_STRICT=1  # require restrictions
 
 Only whitelisted env vars are passed to spawned agents. Each adapter defines its own allowlist (`PATH`, `HOME`, plus adapter-specific like `OPENAI_API_KEY` for Codex). Your shell environment (secrets, tokens, SSH keys) is not inherited by default.
 
-### 3. Process Isolation
+### 3. Input Validation
+
+Model parameters are validated to prevent flag injection (values starting with `-` are rejected). Prompts are capped at 100,000 characters and cannot be empty.
+
+### 4. Process Isolation
 
 Agents run in separate process groups (`start_new_session=True`). Orphan cleanup on exit. Sandbox mode available (`MOONBRIDGE_SANDBOX=1`) for copy-on-run isolation.
 
-### Important caveat
-
-Not OS-level sandboxing. Agents can still read arbitrary host files. For strong isolation, use containers/VMs.
+> **Not OS-level sandboxing.** Agents can still read arbitrary host files. For strong isolation, use containers/VMs.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Adds `## Security` section to README before Troubleshooting
- Documents directory restrictions (`MOONBRIDGE_ALLOWED_DIRS`), environment sanitization, process isolation
- Includes honest caveat about not being OS-level sandboxing

Closes #26

## Test plan
- [x] 169 tests pass
- [x] Content verified against actual code behavior in `server.py`
- [x] No other README sections modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Security guidance: directory allowlist behavior, path/symlink restrictions, strict mode, environment sanitization and allowlists, input validation limits, and process isolation notes.
  * New Sandbox Mode discussion: copy-on-run options, keep/diff/copy behaviors, and clear caveats that this is not OS-level sandboxing.
  * Enhanced Troubleshooting: concrete install/auth steps for adapters and detailed timeout handling and best practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->