### PR TITLE
feat: validate MOONBRIDGE_ALLOWED_DIRS and expose config health

### DIFF
--- a/src/moonbridge/server.py
+++ b/src/moonbridge/server.py
@@ -78,6 +78,22 @@ def _warn_if_unrestricted() -> None:
     print(message, file=sys.stderr)
 
 
+def _validate_allowed_dirs() -> None:
+    if not ALLOWED_DIRS:
+        return
+    missing_count = 0
+    for path in ALLOWED_DIRS:
+        if os.path.isdir(path):
+            continue
+        missing_count += 1
+        logger.warning("MOONBRIDGE_ALLOWED_DIRS entry does not exist: %s", path)
+    if missing_count == len(ALLOWED_DIRS) and STRICT_MODE:
+        message = "MOONBRIDGE_ALLOWED_DIRS entries do not exist"
+        logger.error(message)
+        print(message, file=sys.stderr)
+        sys.exit(1)
+
+
 def _safe_env(adapter: CLIAdapter) -> dict[str, str]:
     env = {key: os.environ[key] for key in adapter.config.safe_env_keys if key in os.environ}
     if "PATH" not in env and "PATH" in os.environ:
@@ -401,6 +417,12 @@ def _json_text(payload: Any) -> list[TextContent]:
 
 
 def _status_check(cwd: str, adapter: CLIAdapter) -> dict[str, Any]:
+    config = {
+        "strict_mode": STRICT_MODE,
+        "allowed_dirs": ALLOWED_DIRS or None,
+        "unrestricted": not ALLOWED_DIRS,
+        "cwd": cwd,
+    }
     installed, _path = adapter.check_installed()
     if not installed:
         return {
@@ -408,20 +430,27 @@ def _status_check(cwd: str, adapter: CLIAdapter) -> dict[str, Any]:
             "message": (
                 f"{adapter.config.name} CLI not found. Install: {adapter.config.install_hint}"
             ),
+            "config": config,
         }
     timeout = min(DEFAULT_TIMEOUT, 60)
     result = _run_cli_sync(adapter, "status check", False, cwd, timeout, 0)
     if result.status == "auth_error":
-        return {"status": "auth_error", "message": adapter.config.auth_message}
+        return {
+            "status": "auth_error",
+            "message": adapter.config.auth_message,
+            "config": config,
+        }
     if result.status == "success":
         return {
             "status": "success",
             "message": f"{adapter.config.name} CLI available and authenticated",
+            "config": config,
         }
     return {
         "status": "error",
         "message": f"{adapter.config.name} CLI error",
         "details": result.to_dict(),
+        "config": config,
     }
 
 
@@ -572,6 +601,7 @@ async def run() -> None:
 def main() -> None:
     _configure_logging()
     _warn_if_unrestricted()
+    _validate_allowed_dirs()
     from moonbridge import __version__
     from moonbridge.version_check import check_for_updates
 

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -2,8 +2,6 @@ import importlib
 from pathlib import Path
 from typing import Any
 
-import pytest
-
 from moonbridge.adapters.base import AgentResult
 
 sandbox_module = importlib.import_module("moonbridge.sandbox")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -262,6 +262,25 @@ async def test_check_status_not_installed(mock_which_no_kimi: Any) -> None:
 
 
 @pytest.mark.asyncio
+async def test_check_status_includes_config(
+    mock_which_no_kimi: Any, monkeypatch: Any
+) -> None:
+    monkeypatch.setattr(server_module, "ALLOWED_DIRS", [])
+    monkeypatch.setattr(server_module, "STRICT_MODE", True)
+    monkeypatch.setattr(server_module.os, "getcwd", lambda: "/workdir")
+
+    result = await server_module.handle_tool("check_status", {})
+    payload = json.loads(result[0].text)
+
+    assert "config" in payload
+    config = payload["config"]
+    assert config["strict_mode"] is True
+    assert config["allowed_dirs"] is None
+    assert config["unrestricted"] is True
+    assert config["cwd"] == server_module.os.path.realpath("/workdir")
+
+
+@pytest.mark.asyncio
 async def test_list_adapters_tool_output(monkeypatch: Any) -> None:
     def fake_run(
         adapter: Any,
@@ -432,6 +451,45 @@ def test_warn_if_unrestricted_no_warning_when_restricted(
     captured = capsys.readouterr()
     assert captured.err == ""
     assert not caplog.records
+
+
+def test_validate_allowed_dirs_warns_missing(monkeypatch: Any, caplog: Any) -> None:
+    monkeypatch.setattr(server_module, "ALLOWED_DIRS", ["/missing"])
+    monkeypatch.setattr(server_module.os.path, "isdir", lambda _path: False)
+    caplog.set_level(logging.WARNING, logger="moonbridge")
+
+    server_module._validate_allowed_dirs()
+
+    assert any(
+        record.levelno == logging.WARNING
+        and record.getMessage() == "MOONBRIDGE_ALLOWED_DIRS entry does not exist: /missing"
+        for record in caplog.records
+    )
+
+
+def test_validate_allowed_dirs_strict_all_missing_exits(
+    monkeypatch: Any, caplog: Any, mocker: Any
+) -> None:
+    monkeypatch.setattr(server_module, "ALLOWED_DIRS", ["/missing", "/missing2"])
+    monkeypatch.setattr(server_module, "STRICT_MODE", True)
+    monkeypatch.setattr(server_module.os.path, "isdir", lambda _path: False)
+    exit_mock = mocker.patch("moonbridge.server.sys.exit")
+    caplog.set_level(logging.ERROR, logger="moonbridge")
+
+    server_module._validate_allowed_dirs()
+
+    exit_mock.assert_called_once_with(1)
+
+
+def test_validate_allowed_dirs_some_valid_no_exit(monkeypatch: Any, mocker: Any) -> None:
+    monkeypatch.setattr(server_module, "ALLOWED_DIRS", ["/missing", "/valid"])
+    monkeypatch.setattr(server_module, "STRICT_MODE", True)
+    monkeypatch.setattr(server_module.os.path, "isdir", lambda path: path == "/valid")
+    exit_mock = mocker.patch("moonbridge.server.sys.exit")
+
+    server_module._validate_allowed_dirs()
+
+    exit_mock.assert_not_called()
 
 
 def test_resolve_timeout_uses_adapter_default(monkeypatch: Any) -> None:


### PR DESCRIPTION
## Summary
- Adds `_validate_allowed_dirs()` at startup: warns on nonexistent paths, exits in strict mode if all invalid
- Extends `check_status` response with `config` block containing strict_mode, allowed_dirs, unrestricted, cwd
- Fixes existing unused import in test_sandbox.py

Closes #67

## Test plan
- [x] `ruff check src/ tests/` passes
- [x] `mypy src/` passes (strict)
- [x] `pytest -v` — 173 tests pass (4 new)
- [x] Validates: warn on missing dir, exit on all-missing+strict, no exit on partial, config in status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup validation for configured directories with warnings for missing paths
  * Status check responses now include configuration details such as access mode, allowed directories, and current working directory

* **Improvements**
  * Enhanced error handling during startup to catch and report directory configuration issues early

<!-- end of auto-generated comment: release notes by coderabbit.ai -->