### PR TITLE
feat: add gpt-5.3-codex to known models

### DIFF
--- a/src/moonbridge/adapters/codex.py
+++ b/src/moonbridge/adapters/codex.py
@@ -50,6 +50,7 @@ class CodexAdapter:
         install_hint="See https://github.com/openai/codex",
         supports_thinking=False,
         known_models=(
+            "gpt-5.3-codex",
             "gpt-5.2-codex",
             "gpt-5.1-codex",
             "gpt-5.1-codex-mini",


### PR DESCRIPTION
## Summary
- Adds `gpt-5.3-codex` to the Codex adapter's `known_models` tuple so `list_adapters` surfaces the new model to MCP clients.
- Arbitrary models already work (passed through to CLI via `-m`); this is informational only.

## Test plan
- [x] `uv run pytest tests/ -v` — 169 passed
- [x] `uv run ruff check src/` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv build` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the GPT-5.3-Codex model option, expanding the available models for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->