### PR TITLE
feat: default codex to gpt-5.3 with xhigh reasoning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,11 +89,13 @@ The MCP library is also stubbed in conftest when not installed, enabling tests t
 | `MOONBRIDGE_LOG_LEVEL` | `WARNING` | Logging verbosity |
 | `MOONBRIDGE_MODEL` | (none) | Global default model for all adapters |
 | `MOONBRIDGE_KIMI_MODEL` | (none) | Kimi-specific model override |
-| `MOONBRIDGE_CODEX_MODEL` | (none) | Codex-specific model override |
+| `MOONBRIDGE_CODEX_MODEL` | (none) | Codex-specific model override (default model: `gpt-5.3-codex`) |
 
 Timeout resolution order: tool param > adapter env var > adapter default > global env var > 600s.
 
-Model resolution order: tool param > adapter env var > global env var > CLI default.
+Model resolution order: tool param > adapter env var > global env var > adapter default > CLI default.
+
+Reasoning effort resolution order: tool param > adapter default (`codex` = `xhigh`).
 
 All model values are validated: whitespace is stripped, empty strings become None, and models starting with `-` are rejected (flag injection prevention).
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ Three approaches. One request. You choose the winner.
 |-----------|------|----------|-------------|
 | `prompt` | string | Yes | Task description for the agent |
 | `adapter` | string | No | Backend to use: `kimi`, `codex` (default: `kimi`) |
-| `model` | string | No | Model override (e.g., `gpt-5.2-codex`) |
+| `model` | string | No | Model override (e.g., `gpt-5.2-codex`). For `codex`, default is `gpt-5.3-codex`. |
 | `thinking` | boolean | No | Enable reasoning mode (Kimi only) |
-| `reasoning_effort` | string | No | Reasoning budget: `low`, `medium`, `high`, `xhigh` (Codex only) |
+| `reasoning_effort` | string | No | Reasoning budget: `low`, `medium`, `high`, `xhigh` (Codex only, default `xhigh`) |
 | `timeout_seconds` | integer | No | Override default timeout (30-3600) |
 
 **`spawn_agents_parallel`**
@@ -130,9 +130,9 @@ Three approaches. One request. You choose the winner.
 | `agents` | array | Yes | List of agent configs (max 10) |
 | `agents[].prompt` | string | Yes | Task for this agent |
 | `agents[].adapter` | string | No | Backend for this agent |
-| `agents[].model` | string | No | Model override for this agent |
+| `agents[].model` | string | No | Model override for this agent (`codex` default: `gpt-5.3-codex`) |
 | `agents[].thinking` | boolean | No | Enable reasoning (Kimi only) |
-| `agents[].reasoning_effort` | string | No | Reasoning budget (Codex only) |
+| `agents[].reasoning_effort` | string | No | Reasoning budget (Codex only, default `xhigh`) |
 | `agents[].timeout_seconds` | integer | No | Timeout for this agent |
 
 ## Response Format

--- a/src/moonbridge/adapters/base.py
+++ b/src/moonbridge/adapters/base.py
@@ -16,6 +16,8 @@ class AdapterConfig:
     supports_thinking: bool
     known_models: tuple[str, ...] = ()  # Known model options for this adapter
     default_timeout: int = 600
+    default_model: str | None = None
+    default_reasoning_effort: str | None = None
 
 
 @dataclass(frozen=True)

--- a/src/moonbridge/adapters/codex.py
+++ b/src/moonbridge/adapters/codex.py
@@ -57,6 +57,8 @@ class CodexAdapter:
             "gpt-5.1-codex-max",
         ),
         default_timeout=1800,  # 30 minutes - Codex runs long
+        default_model="gpt-5.3-codex",
+        default_reasoning_effort="xhigh",
     )
 
     def build_command(

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -285,6 +285,8 @@ def test_codex_adapter_config_values():
     assert adapter.config.name == "codex"
     assert adapter.config.cli_command == "codex"
     assert adapter.config.supports_thinking is False
+    assert adapter.config.default_model == "gpt-5.3-codex"
+    assert adapter.config.default_reasoning_effort == "xhigh"
     assert "OPENAI_API_KEY" in adapter.config.safe_env_keys
     assert "Codex" in adapter.config.tool_description
 


### PR DESCRIPTION
## Summary
- add adapter-level defaults for model and reasoning effort in AdapterConfig
- set Codex defaults to gpt-5.3-codex and xhigh
- resolve model as: param > adapter env > global env > adapter default
- resolve reasoning effort as: param > adapter default
- apply defaults for both spawn_agent and spawn_agents_parallel
- update docs and add coverage for default behavior

## Validation
- uv run pytest -q
- uv run ruff check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex adapter now includes intelligent defaults: model automatically set to gpt-5.3-codex and reasoning effort to xhigh, improving out-of-the-box experience
  * Adapter configuration now supports customizable defaults for model selection and reasoning effort, enabling better fallback behavior

* **Documentation**
  * Updated documentation to reflect Codex adapter defaults and clarify parameter resolution order

<!-- end of auto-generated comment: release notes by coderabbit.ai -->