### PR TITLE
fix: cap agent output to prevent oversized tool payload hangs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@
 # Maximum number of parallel agents
 # MOONBRIDGE_MAX_AGENTS=10
 
+# Maximum characters returned per agent (stdout + stderr combined)
+# MOONBRIDGE_MAX_OUTPUT_CHARS=120000
+
 # Colon-separated allowlist of working directories
 # Leave unset to allow all directories
 # MOONBRIDGE_ALLOWED_DIRS=/path/to/project:/another/path

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ The MCP library is also stubbed in conftest when not installed, enabling tests t
 | `MOONBRIDGE_CODEX_TIMEOUT` | `1800` | Codex-specific timeout (30min default) |
 | `MOONBRIDGE_KIMI_TIMEOUT` | `600` | Kimi-specific timeout (10min default) |
 | `MOONBRIDGE_MAX_AGENTS` | `10` | Max parallel agents |
+| `MOONBRIDGE_MAX_OUTPUT_CHARS` | `120000` | Max chars returned per agent across `stdout`+`stderr` (timeout tails are per stream) |
 | `MOONBRIDGE_ALLOWED_DIRS` | (none) | Colon-separated directory allowlist |
 | `MOONBRIDGE_STRICT` | `false` | Exit if ALLOWED_DIRS unset |
 | `MOONBRIDGE_LOG_LEVEL` | `WARNING` | Logging verbosity |

--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ All tools return JSON with these fields:
 | `message` | string? | Human-readable error context (when applicable) |
 | `raw` | object? | Optional structured metadata (e.g., sandbox diff) |
 
+When output is too large, Moonbridge truncates it and adds `raw.output_limit` metadata
+with original sizes.
+
 ## Configuration
 
 ### Environment Variables
@@ -159,6 +162,7 @@ All tools return JSON with these fields:
 | `MOONBRIDGE_ADAPTER` | Default adapter (default: `kimi`) |
 | `MOONBRIDGE_TIMEOUT` | Default timeout in seconds (30-3600) |
 | `MOONBRIDGE_MAX_AGENTS` | Maximum parallel agents |
+| `MOONBRIDGE_MAX_OUTPUT_CHARS` | Max chars returned per agent across `stdout`+`stderr` (default 120000; timeout tails are per stream) |
 | `MOONBRIDGE_ALLOWED_DIRS` | Colon-separated allowlist of working directories |
 | `MOONBRIDGE_STRICT` | Set to `1` to require `ALLOWED_DIRS` (exits if unset) |
 | `MOONBRIDGE_SANDBOX` | Set to `1` to run agents in a temp copy of cwd |


### PR DESCRIPTION
## Summary
- add hard output truncation guards in Moonbridge server responses
- cap normal responses by combined `stdout` + `stderr` budget (`MOONBRIDGE_MAX_OUTPUT_CHARS`, default `120000`)
- preserve timeout-tail behavior per stream and annotate truncation metadata in `raw.output_limit`
- document the new guardrail in `README.md`, `CLAUDE.md`, and `.env.example`
- add tests for large success/auth output truncation and metadata

## Why
Moonbridge responses could include multi-megabyte output payloads, causing downstream MCP clients to become slow/unresponsive while reading tool-result files.

## Validation
- `uv run pytest -q` (196 passed)
- `uv run ruff check src tests`
- `uv run mypy src`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced output limiting with the MOONBRIDGE_MAX_OUTPUT_CHARS environment variable (default: 120,000 characters per agent). Large outputs are now truncated with metadata indicating original character counts.

* **Documentation**
  * Updated configuration documentation to describe the new output limiting feature.

* **Tests**
  * Added tests for output truncation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->