### PR TITLE
ci: fix cerberus workflow api key input

### DIFF
--- a/.github/workflows/cerberus.yml
+++ b/.github/workflows/cerberus.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   review:
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     name: "${{ matrix.reviewer }}"
     runs-on: ubuntu-latest
     strategy:
@@ -29,18 +30,19 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: misty-step/cerberus@v1
+      - uses: misty-step/cerberus@bd596a2ebc2bb5fa6cfaa79c4f128fa22b847532 # v1
         with:
           perspective: ${{ matrix.perspective }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          api-key: ${{ secrets.OPENROUTER_API_KEY || secrets.MOONSHOT_API_KEY }}
+          # Must be OpenRouter key (legacy alias: MOONSHOT_API_KEY).
+          api-key: ${{ secrets.CERBERUS_API_KEY || secrets.OPENROUTER_API_KEY || secrets.MOONSHOT_API_KEY }}
 
   verdict:
     name: "Council Verdict"
     needs: review
-    if: always()
+    if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
-      - uses: misty-step/cerberus/verdict@v1
+      - uses: misty-step/cerberus/verdict@bd596a2ebc2bb5fa6cfaa79c4f128fa22b847532 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Cerberus checks are failing fast because the workflow passes an obsolete input (`kimi-api-key`).

`misty-step/cerberus@v1` expects `api-key` (OpenRouter/Cerberus) and exits early when missing, so no verdict artifacts get uploaded and the council aggregation job also fails.

## Change
- Update `.github/workflows/cerberus.yml` to pass `api-key`.
- Expression prefers `OPENROUTER_API_KEY` if present, else falls back to existing `MOONSHOT_API_KEY` secret.

## Notes
If `MOONSHOT_API_KEY` is not an OpenRouter key, reviewers will likely SKIP (API auth/quota) but the workflow will no longer hard-fail on input validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now gates the review job to PRs originating from the same repository.
  * Third‑party action usage pinned to a fixed revision for stability.
  * Renamed input to a unified api-key and broadened secret resolution to accept multiple possible API key variables.
  * Verdict step condition adjusted to respect the repository gate.
  * Added a clarifying comment about required API key/legacy alias.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->