### PR TITLE
ci: add merge gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
 
   merge-gate:
     name: merge-gate
+    timeout-minutes: 5
     # NOTE: add every new deterministic CI job to this list so the merge gate stays complete.
     needs: [test]
     runs-on: ubuntu-latest
@@ -55,7 +56,11 @@ jobs:
           )
 
           if blocked:
-              print(f"merge-gate red ({summary})")
+              blocked_summary = ", ".join(
+                  f"{job_name}={result}"
+                  for job_name, result in sorted(blocked.items())
+              )
+              print(f"merge-gate red — failed: {blocked_summary} | all: {summary}")
               sys.exit(1)
 
           print(f"merge-gate green ({summary})")

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           NEEDS_CONTEXT: ${{ toJSON(needs) }}
         run: |
-          python - <<'PY'
+          python3 - <<'PY'
           import json
           import os
           import sys

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,14 +28,35 @@ jobs:
 
   merge-gate:
     name: merge-gate
+    # NOTE: add every new deterministic CI job to this list so the merge gate stays complete.
     needs: [test]
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - run: |
-          if [[ "${{ needs.test.result }}" == "success" ]]; then
-            echo "merge-gate green"
-          else
-            echo "merge-gate red (test=${{ needs.test.result }})"
-            exit 1
-          fi
+      - name: Check upstream job results
+        env:
+          NEEDS_CONTEXT: ${{ toJSON(needs) }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["NEEDS_CONTEXT"])
+          passing_states = {"success", "skipped"}
+          blocked = {
+              job_name: metadata.get("result", "unknown")
+              for job_name, metadata in needs.items()
+              if metadata.get("result") not in passing_states
+          }
+          summary = ", ".join(
+              f"{job_name}={metadata.get('result', 'unknown')}"
+              for job_name, metadata in sorted(needs.items())
+          )
+
+          if blocked:
+              print(f"merge-gate red ({summary})")
+              sys.exit(1)
+
+          print(f"merge-gate green ({summary})")
+          PY

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,17 @@ jobs:
         run: mypy src/
       - name: Pytest
         run: pytest -v
+
+  merge-gate:
+    name: merge-gate
+    needs: [test]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - run: |
+          if [[ "${{ needs.test.result }}" == "success" ]]; then
+            echo "merge-gate green"
+          else
+            echo "merge-gate red (test=${{ needs.test.result }})"
+            exit 1
+          fi


### PR DESCRIPTION
## Why This Matters
- Problem: the repo needed a single deterministic merge gate, but the initial implementation still had a few reviewer-raised sharp edges around maintainability, failure readability, and runner assumptions.
- Value: this PR leaves Moonbridge with one stable required-check surface that still preserves the real test matrix beneath it.
- Why now: org policy is converging on one trustworthy merge gate per repo, and this PR is already the lane carrying that normalization work.
- Issue: follow-up docs/maintenance hardening is tracked in #108.

## Trade-offs / Risks
- Value gained: simpler branch protection and clearer CI triage when the gate fails.
- Cost / risk incurred: the workflow now contains a slightly richer inline Python reducer, which is more logic than a one-line bash check.
- Why this is still the right trade: the reducer is now name-agnostic, explicit about passing states, and prints the blocked jobs directly, which makes the single-gate abstraction more trustworthy.
- Reviewer watch-outs: confirm the workflow still fans in the intended jobs through `needs`, and that `merge-gate` stays green only when upstream deterministic jobs succeed or are intentionally skipped.

## What Changed
This PR adds a stable `merge-gate` job and then tightens it so the gate is readable, name-agnostic, and explicit about what blocks merges.

### Base Branch
```mermaid
graph TD
  A[Test matrix runs] --> B[Branch protection depends on multiple moving checks]
  B --> C[No single deterministic gate summarizes CI truth]
```

### This PR
```mermaid
graph TD
  A[Test matrix runs] --> B[merge-gate consumes needs context]
  B --> C[success/skipped treated as passing]
  B --> D[blocked jobs printed clearly on failure]
  C --> E[one stable required check can guard merges]
```

### Architecture / State Change
```mermaid
stateDiagram-v2
  [*] --> MultiCheckSurface
  MultiCheckSurface --> StableGate: add merge-gate job
  StableGate --> HardenedGate: name-agnostic reducer + explicit python3 + blocked-job output
  HardenedGate --> [*]
```

Why this is better:
- the gate no longer depends on a specific upstream job name inside its reducer
- failed jobs are surfaced directly in the red path, which speeds CI triage
- `python3` makes the runner dependency explicit instead of relying on an alias

<details>
<summary>Intent Reference</summary>

## Intent Reference
- Normalize Moonbridge onto the org-wide single merge-gate pattern.
- Reviewer feedback during stewardship tightened the implementation around clarity and durability.
- Repo-level maintenance follow-up for `merge-gate.needs` is tracked in #108.

</details>

<details>
<summary>Changes</summary>

## Changes
- `.github/workflows/test.yml`
  - adds `merge-gate`
  - documents the `needs` maintenance contract inline
  - reduces upstream results name-agnostically via `${{ toJSON(needs) }}`
  - treats `success` and `skipped` as passing states
  - prints a focused blocked-job summary on failure
  - invokes `python3` explicitly

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] Repo has a single deterministic `merge-gate` status suitable for branch protection.
- [x] The gate fails when any upstream deterministic job is not `success` or `skipped`.
- [x] Failure output identifies the blocked jobs directly.
- [x] All review threads are resolved before merge.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A — Keep multiple required checks
- Upside: less workflow logic.
- Downside: branch protection stays noisier and less portable across repos.
- Why rejected: the org is standardizing on one deterministic gate.

### Option B — Keep the first merge-gate draft unchanged
- Upside: smaller diff.
- Downside: it left maintainability and triage feedback unresolved.
- Why rejected: reviewer concerns were legitimate and cheap to fix.

### Option C — Harden the merge-gate in this PR
- Upside: ships the normalized gate in a state reviewers can trust.
- Downside: slightly more workflow logic plus a docs follow-up issue.
- Why chosen: it closes the current lane cleanly without deferring obvious polish.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yml"); puts "yaml ok"'`
- `uv venv --python 3.11 .venv311 && uv pip install -e '.[dev]'`
- `ruff check src/`
- `mypy src/`
- `pytest -v`
- merge-gate reducer smoke cases for `success`, `skipped`, `failure`, and mixed upstream states

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- Renderer: Terminal walkthrough
- Artifact: PR discussion + CI evidence on this PR
- Claim: Moonbridge now has a single stable merge gate whose result matches the upstream deterministic CI jobs and produces clearer failure output
- Before / After scope: GitHub Actions workflow behavior for the test matrix and merge gate
- Persistent verification: `merge-gate` plus the `test (3.11/3.12/3.13)` checks on this PR
- Residual gap: `merge-gate.needs` still relies on documented manual maintenance; repo-level docs follow-up is tracked in #108

</details>

<details>
<summary>Before / After</summary>

## Before / After
- Before: Moonbridge lacked a normalized single merge gate, and the initial draft still needed reviewer-driven tightening around reducer coupling, error output, and Python invocation clarity.
- After: the repo has a deterministic `merge-gate` with clearer failure messaging, explicit `python3`, and all open review threads resolved.

Screenshots are omitted because this is workflow-only work; the relevant proof is the GitHub Actions run and the workflow diff.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- GitHub checks:
  - `test (3.11)`
  - `test (3.12)`
  - `test (3.13)`
  - `merge-gate`
  - Greptile / CodeRabbit / Cerberus review suite
- Local verification:
  - YAML parse
  - `ruff check src/`
  - `mypy src/`
  - `pytest -v`
  - targeted reducer smoke cases

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- Confidence level: medium-high, rising to high once the final post-`efc5b9c` checks finish green.
- Strongest evidence: all review threads are resolved, the workflow logic was exercised locally, and prior reruns on the same reducer shape were green.
- Remaining uncertainty: the last push is small but still waiting on full GitHub Actions confirmation.
- What could still go wrong after merge: future deterministic jobs could still be omitted from `needs` unless follow-up #108 lands.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated merge gate in CI that validates upstream job results before allowing merges.
  * The gate runs on each workflow execution, aggregates upstream outcomes into a concise summary, and blocks merges when any upstream job is failing, presenting a clear pass/fail status to inform merge decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->